### PR TITLE
Use modern PIL interface

### DIFF
--- a/src/camera.py
+++ b/src/camera.py
@@ -28,7 +28,7 @@ class Camera:
         """Get a new image from the camera."""
         for _ in range(5): #HACK TODO document this
             im = cv.QueryFrame(self._cam)
-        return Image.fromstring("RGB", cv.GetSize(im), im.tostring(), "raw",
+        return Image.frombytes("RGB", cv.GetSize(im), im.tobytes(), "raw",
                                 "BGR", 0, 1) 
     
     def __del__(self):

--- a/src/capture.py
+++ b/src/capture.py
@@ -29,7 +29,7 @@ class Screen:
 
     def display_picture(self, im):
         """Display image on PyGame screen."""
-        pg_img = pygame.image.frombuffer(im.tostring(), im.size, im.mode)
+        pg_img = pygame.image.frombuffer(im.tobytes(), im.size, im.mode)
         self._screen.blit(pg_img, (0,0))
         pygame.display.flip()
 

--- a/src/filters.py
+++ b/src/filters.py
@@ -41,8 +41,8 @@ def edge_detection(image):
     new_image = image.filter(ImageFilter.GaussianBlur())
     # GaussianBlur is undocumented class, it might not work in future versions
     # of PIL
-    new_image = Image.fromstring('L', image.size,
-                             pcf.edge(image.size, image.tostring()))
+    new_image = Image.frombytes('L', image.size,
+                             pcf.edge(image.size, image.tobytes()))
     return new_image
 
 def peaks(image):

--- a/src/gridf_new.py
+++ b/src/gridf_new.py
@@ -250,7 +250,7 @@ def find(lines, size, l1, l2, bounds, hough, show_all, do_something, logger):
             fig.canvas.draw()
             size_f = fig.canvas.get_width_height()
             buff = fig.canvas.tostring_rgb()
-            image_p = Image.fromstring('RGB', size_f, buff, 'raw')
+            image_p = Image.frombytes('RGB', size_f, buff, 'raw')
             do_something(image_p, "finding diagonals")
 
         logger("finding the grid")

--- a/src/gridf_old.py
+++ b/src/gridf_old.py
@@ -54,7 +54,7 @@ def find(lines, size, l1, l2, bounds, hough, show_all, do_something, logger):
 
     im_l = im_l.filter(MyGaussianBlur(radius=3))
     #GaussianBlur is undocumented class, may not work in future versions of PIL
-    im_l_s = im_l.tostring()
+    im_l_s = im_l.tobytes()
 
     #import time
     #start = time.time()
@@ -130,5 +130,5 @@ def distance(im_l, grid, size):
     #im_g = im_g.filter(MyGaussianBlur(radius=3))
     #GaussianBlur is undocumented class, may not work in future versions of PIL
     #im_d, distance = combine(im_l, im_g)
-    distance_d = pcf.combine(im_l, im_g.tostring())
+    distance_d = pcf.combine(im_l, im_g.tobytes())
     return distance_d

--- a/src/hough.py
+++ b/src/hough.py
@@ -25,9 +25,9 @@ class Hough:
         return cls(size, dt, initial_angle)
 
     def transform(self, image):
-        image_s = pcf.hough(self.size, image.tostring(), self.initial_angle,
+        image_s = pcf.hough(self.size, image.tobytes(), self.initial_angle,
                             self.dt)
-        image_t = Image.fromstring('L', self.size, image_s)
+        image_t = Image.frombytes('L', self.size, image_s)
         return image_t
 
     def apply_filter(self, filter_f):

--- a/src/im_debug.py
+++ b/src/im_debug.py
@@ -23,7 +23,7 @@ def show(image, caption='', name=None):
     pygame.display.set_caption(caption)
     pygame.display.set_mode(image.size)
     main_surface = pygame.display.get_surface()
-    picture = pygame.image.frombuffer(image.tostring(), image.size, image.mode)
+    picture = pygame.image.frombuffer(image.tobytes(), image.size, image.mode)
     main_surface.blit(picture, (0, 0))
     pygame.display.update()
     while True:

--- a/src/intrsc.py
+++ b/src/intrsc.py
@@ -80,7 +80,7 @@ def board(image, intersections, show_all, do_something, logger):
         fig.canvas.draw()
         size = fig.canvas.get_width_height()
         buff = fig.canvas.tostring_rgb()
-        image_p = Image.fromstring('RGB', size, buff, 'raw')
+        image_p = Image.frombytes('RGB', size, buff, 'raw')
         do_something(image_p, "color distribution")
 
     color_data = [(s[0], s[1]) for s in board_raw]
@@ -103,7 +103,7 @@ def board(image, intersections, show_all, do_something, logger):
         fig.canvas.draw()
         size = fig.canvas.get_width_height()
         buff = fig.canvas.tostring_rgb()
-        image_p = Image.fromstring('RGB', size, buff, 'raw')
+        image_p = Image.frombytes('RGB', size, buff, 'raw')
         do_something(image_p, "color clustering")
 
     clusters[0] = [(p[1], 'B') for p in clusters[0]]

--- a/src/manual.py
+++ b/src/manual.py
@@ -19,7 +19,7 @@ class Screen:
         self._screen = pygame.display.get_surface()
 
     def display_picture(self, img):
-        pg_img = pygame.image.frombuffer(img.tostring(), img.size, img.mode)
+        pg_img = pygame.image.frombuffer(img.tobytes(), img.size, img.mode)
         self._screen.blit(pg_img, (0, 0))
         pygame.display.flip()
 


### PR DESCRIPTION
Hi Tomas, this PR updates the calls that imago makes into PIL to use the newer "to/from bytes" interface, rather than the older "to/from string" interface.  This was necessary to get it to run on Pillow 3.3.0 in Debian Stretch.
