### PR TITLE
Add test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install:
 # command to run tests
 script:
   - ./imago image.jpg
+  - ./runtests

--- a/README.md
+++ b/README.md
@@ -27,3 +27,20 @@ Run `./imago image.jpg` to extract game position from image.jpg.
 Run `./imago -m image.jpg` to manually select grid position.
 Run `./imago image000.jpg image001.jpg image002.jpg ...` to produce a game record from a sequence of images, one for every move. Use `-S` option to select SGF output. 
 Run `./imago --help` for help and list of all options.
+
+## Tests
+
+The imago test suite lives in the
+[imago-tests](https://github.com/tomasmcz/imago-tests) repo, available
+as a submodule of the [imago](https://github.com/tomasmcz/imago) repo
+in the tests/ directory.
+
+To run the tests, build imago and run "./runtests" from the root of the
+working directory.
+
+The runtests program runs imago on each input image and compares the
+output to the expected.  Any discrepancy is a test failure.
+
+Failing tests can be disabled by moving them into a directory named
+"skip".  "skip" directories are by default ignored by the runtests
+program.  Run "./runtests --all" to include tests marked "skip".

--- a/runtests
+++ b/runtests
@@ -41,7 +41,7 @@ for INPUT in $INPUTS; do
 
     # Run imago on the input file, check for failure.
     rm -f $INPUT.out
-    ./imago $INPUT > $INPUT.out
+    ./imago --rng-seed "runtests rng seed" $INPUT > $INPUT.out
     if [ $? -ne 0 ]; then
         echo "ERROR: imago returned failure"
         FAILED="$FAILED $INPUT"

--- a/runtests
+++ b/runtests
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# This script runs all the automated tests, or a select set of tests
+# named on the command line.
+#
+# Inputs are image files (.jpg and .png), expected imago results are the
+# matching .txt files.
+#
+
+# The "--all" argument to runtests runs all tests, even the ones marked
+# "skip".
+OPTIONAL_SKIP="-name skip -prune -o"
+if [ "$1" = "--all" ]; then
+    OPTIONAL_SKIP=""
+    shift
+fi
+
+
+# Run all tests in 'tests/' by default, or whatever ones the user named
+# on the command-line.  Ignore any subdirectories named "skip", so that
+# flaky tests can be easily (temporarily?) disabled.
+if [ -z "$*" ]; then
+    INPUT_SEARCH='tests/'
+else
+    INPUT_SEARCH="$*"
+fi
+INPUTS=$(find $INPUT_SEARCH $OPTIONAL_SKIP \( -name '*.jpg' -o -name '*.png' \) -print | sort)
+
+FAILED=''
+
+for INPUT in $INPUTS; do
+    echo running test: $INPUT
+
+    # Skip input image files that don't have a matching .txt file
+    # containing expected output.
+    EXPECTED=$(dirname $INPUT)/$(basename ${INPUT%.*}).txt
+    if [ ! -f $EXPECTED ]; then
+        echo "no expected-output file found"
+        continue
+    fi
+
+    # Run imago on the input file, check for failure.
+    rm -f $INPUT.out
+    ./imago $INPUT > $INPUT.out
+    if [ $? -ne 0 ]; then
+        echo "ERROR: imago returned failure"
+        FAILED="$FAILED $INPUT"
+        continue
+    fi
+
+    # imago ran successfully on the input file, compare output to expected.
+    diff -u $EXPECTED $INPUT.out
+    if [ $? -ne 0 ]; then
+        echo "ERROR: imago produced unexpected output"
+        FAILED="$FAILED $INPUT"
+    else
+        # clean up after this passed test
+        rm -f $INPUT.out
+    fi
+done
+
+# Report all the tests that failed.
+if [ -n "$FAILED" ]; then
+    echo "tests failed:"
+    for F in $FAILED; do
+        echo "    $F"
+    done
+    exit 1
+fi

--- a/src/imago.py
+++ b/src/imago.py
@@ -6,6 +6,7 @@ import sys
 import os
 import argparse
 import pickle
+import random
 
 try:
     from PIL import Image, ImageDraw
@@ -38,6 +39,7 @@ def argument_parser():
                         help="output in SGF")
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help="report progress")
+    parser.add_argument('--rng-seed', dest='rng_seed', help="Specify random number generator seed, for consistent test results.")
     return parser
  
 
@@ -50,6 +52,8 @@ def main():
 
     show_all = args.show_all
     verbose = args.verbose
+
+    random.seed(args.rng_seed)
 
     try:
         image = Image.open(args.files[0])


### PR DESCRIPTION
This branch adds the tests from test3.zip, and a little shell script to run imago on all of them and report failures.

Some of the t2 tests fail often on my development system and have been disabled.  The failing tests are still in the tests/ dir (to facilitate debugging) but don't get run by default.  Details in tests/README.
